### PR TITLE
Cleaner way of showing "String"

### DIFF
--- a/colors/noctu.vim
+++ b/colors/noctu.vim
@@ -73,7 +73,7 @@ hi Delimiter       ctermfg=7
 hi Comment         ctermfg=8
 hi Underlined      ctermfg=4   cterm=underline
 hi Type            ctermfg=4
-hi String          ctermfg=9
+hi String          ctermfg=14
 hi Keyword         ctermfg=2
 hi Todo            ctermfg=15  ctermbg=NONE     cterm=bold,underline
 hi Function        ctermfg=4


### PR DESCRIPTION
Usually color9 is picked as a red color, this way strings get really
highlighted and usually this shouldn't get the attention.

color14 is more like an alternative color, usually picked as cyan, and
shouldn't be as intrusive as red is in any kind of colorscheme